### PR TITLE
Agregado middleware de error

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var cors = require('cors')
 require('./config/database')
-
+const errorHandler = require('./middleware/errorHandler');
 var indexRouter = require('./routes/index');
 
 var app = express();
@@ -24,10 +24,7 @@ app.use(cors());
 
 app.use('/', indexRouter);
 
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  next(createError(404));
-});
+app.use(errorHandler.notFound);
 
 // error handler
 app.use(function(err, req, res, next) {

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,7 @@
+const errorHandler = {
+  notFound(req, res, next) {
+    res.status(404).json({ message: `Route ${req.url} with the method ${req.method} isn't implemented` });
+  },
+};
+
+module.exports = errorHandler;


### PR DESCRIPTION
Se realizó un middleware de error para una respuesta personalizada del error 404:
![image](https://user-images.githubusercontent.com/37635593/201711090-a616f77b-ad8c-403c-87da-b3dec44efeef.png)

El middleware se coloca luego de las rutas para que no interfiera con el correr común de la app, pero antes del error handler general.
![image](https://user-images.githubusercontent.com/37635593/201711787-2945ed30-1551-47bd-b84d-c819804c967b.png)

Por lo que ahora cuando no hay una ruta, muestra un mensaje de error en JSON:
![image](https://user-images.githubusercontent.com/37635593/201712092-45eeecef-906e-4ebd-8bfa-bd169d5c04d5.png)

Pero cuando existe, muestra la respuesta correcta:
![image](https://user-images.githubusercontent.com/37635593/201712201-2aacb330-7147-4f55-80e4-d773162f8e3d.png)
